### PR TITLE
TRIAGE-771 Update Image Scan Key

### DIFF
--- a/src/steps/scans/__snapshots__/converters.test.ts.snap
+++ b/src/steps/scans/__snapshots__/converters.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "_class": Array [
     "Assessment",
   ],
-  "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d",
+  "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d:1638870815",
   "_rawData": Array [
     Object {
       "name": "default",

--- a/src/steps/scans/__snapshots__/index.test.ts.snap
+++ b/src/steps/scans/__snapshots__/index.test.ts.snap
@@ -181,7 +181,7 @@ Object {
       "_class": Array [
         "Assessment",
       ],
-      "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d",
+      "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d:1638870815",
       "_rawData": Array [
         Object {
           "name": "default",
@@ -228,8 +228,8 @@ Object {
     Object {
       "_class": "HAS",
       "_fromEntityKey": "sysdig_account:10006755",
-      "_key": "sysdig_account:10006755|has|sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d",
-      "_toEntityKey": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d",
+      "_key": "sysdig_account:10006755|has|sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d:1638870815",
+      "_toEntityKey": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d:1638870815",
       "_type": "sysdig_account_has_image_scan",
       "displayName": "HAS",
     },
@@ -250,7 +250,7 @@ Object {
       "_class": Array [
         "Assessment",
       ],
-      "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d",
+      "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d:1638870815",
       "_rawData": Array [
         Object {
           "name": "default",

--- a/src/steps/scans/converter.ts
+++ b/src/steps/scans/converter.ts
@@ -6,8 +6,8 @@ import { SysdigResult } from '../../types';
 
 import { Entities } from '../constants';
 
-export function getImageScanKey(id: string): string {
-  return `sysdig_image_scan:${id}`;
+export function getImageScanKey(id: string, analyzedAt: number): string {
+  return `sysdig_image_scan:${id}:${analyzedAt}`;
 }
 
 export function createImageScanEntity(data: SysdigResult): Entity {
@@ -15,7 +15,7 @@ export function createImageScanEntity(data: SysdigResult): Entity {
     entityData: {
       source: data,
       assign: {
-        _key: getImageScanKey(data.imageId),
+        _key: getImageScanKey(data.imageId, data.analyzedAt),
         _type: Entities.IMAGE_SCAN._type,
         _class: Entities.IMAGE_SCAN._class,
         name: data.repository,


### PR DESCRIPTION
# Description

We've received duplicate `_key` errors from `sysdig_image_scan`s. The current `_key` is based on
the image's imageId, but if the same image was scanned multiple times, this may not be a unique value.

I've added the `analysis` time as part of the `_key` to hopefully add enough uniqueness to be globally unique.


## Commits

- fix: add analyzed time to image scan key
- update snapshots
