### PR TITLE
triage 771 skip duplicate creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -87,6 +87,7 @@ jobs:
           tag_name: ${{ steps.changelog_reader.outputs.version }}
           release_name: Release ${{ steps.changelog_reader.outputs.version }}
           body: ${{ steps.changelog_reader.outputs.changes }}
-          prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
+          prerelease:
+            ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
           draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}
         continue-on-error: true

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,5 +1,5 @@
 name: gitleaks
-on: 
+on:
   pull_request:
   push:
     branches:

--- a/.github/workflows/questions.yml
+++ b/.github/workflows/questions.yml
@@ -14,9 +14,9 @@ jobs:
 
       - name: Check out `main` branch
         uses: actions/checkout@v2
-        with: 
+        with:
           path: source
-      
+
       - name: Check out target branch questions
         uses: actions/checkout@v2
         with:
@@ -29,10 +29,12 @@ jobs:
 
       - name: Validate questions on target branch
         env:
-          MANAGED_QUESTIONS_JUPITERONE_ACCOUNT_ID: ${{ secrets.MANAGED_QUESTIONS_JUPITERONE_ACCOUNT_ID }}
-          MANAGED_QUESTIONS_JUPITERONE_API_KEY: ${{ secrets.MANAGED_QUESTIONS_JUPITERONE_API_KEY }}
-        run: yarn --cwd source 
-               j1-integration validate-question-file 
-                 -a $MANAGED_QUESTIONS_JUPITERONE_ACCOUNT_ID 
-                 -k $MANAGED_QUESTIONS_JUPITERONE_API_KEY 
-                 -p ../target/jupiterone/questions/questions.yaml
+          MANAGED_QUESTIONS_JUPITERONE_ACCOUNT_ID:
+            ${{ secrets.MANAGED_QUESTIONS_JUPITERONE_ACCOUNT_ID }}
+          MANAGED_QUESTIONS_JUPITERONE_API_KEY:
+            ${{ secrets.MANAGED_QUESTIONS_JUPITERONE_API_KEY }}
+        run:
+          yarn --cwd source j1-integration validate-question-file -a
+          $MANAGED_QUESTIONS_JUPITERONE_ACCOUNT_ID -k
+          $MANAGED_QUESTIONS_JUPITERONE_API_KEY -p
+          ../target/jupiterone/questions/questions.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.2.3 - 2022-08-31
+
+### Changed
+
+- Skipping duplicate `sysdig_image_scan` creation and adding informational
+  gathering logs to understand duplicate images scans better.
+
 ## 0.2.2 - 2022-08-31
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-sysdig",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A graph conversion tool for https://sysdig.com/",
   "license": "MPL-2.0",
   "main": "src/index.js",

--- a/src/steps/scans/__snapshots__/converters.test.ts.snap
+++ b/src/steps/scans/__snapshots__/converters.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "_class": Array [
     "Assessment",
   ],
-  "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d:1638870815",
+  "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d",
   "_rawData": Array [
     Object {
       "name": "default",

--- a/src/steps/scans/__snapshots__/index.test.ts.snap
+++ b/src/steps/scans/__snapshots__/index.test.ts.snap
@@ -181,7 +181,7 @@ Object {
       "_class": Array [
         "Assessment",
       ],
-      "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d:1638870815",
+      "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d",
       "_rawData": Array [
         Object {
           "name": "default",
@@ -228,8 +228,8 @@ Object {
     Object {
       "_class": "HAS",
       "_fromEntityKey": "sysdig_account:10006755",
-      "_key": "sysdig_account:10006755|has|sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d:1638870815",
-      "_toEntityKey": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d:1638870815",
+      "_key": "sysdig_account:10006755|has|sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d",
+      "_toEntityKey": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d",
       "_type": "sysdig_account_has_image_scan",
       "displayName": "HAS",
     },
@@ -250,7 +250,7 @@ Object {
       "_class": Array [
         "Assessment",
       ],
-      "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d:1638870815",
+      "_key": "sysdig_image_scan:29616510799237b94b21e67dbf112411ccea244ed875cd54370d2167ec62b05d",
       "_rawData": Array [
         Object {
           "name": "default",

--- a/src/steps/scans/converter.ts
+++ b/src/steps/scans/converter.ts
@@ -6,8 +6,8 @@ import { SysdigResult } from '../../types';
 
 import { Entities } from '../constants';
 
-export function getImageScanKey(id: string, analyzedAt: number): string {
-  return `sysdig_image_scan:${id}:${analyzedAt}`;
+export function getImageScanKey(id: string): string {
+  return `sysdig_image_scan:${id}`;
 }
 
 export function createImageScanEntity(data: SysdigResult): Entity {
@@ -15,7 +15,7 @@ export function createImageScanEntity(data: SysdigResult): Entity {
     entityData: {
       source: data,
       assign: {
-        _key: getImageScanKey(data.imageId, data.analyzedAt),
+        _key: getImageScanKey(data.imageId),
         _type: Entities.IMAGE_SCAN._type,
         _class: Entities.IMAGE_SCAN._class,
         name: data.repository,


### PR DESCRIPTION
# Description

There are still duplicates after adding `analyzedAt` the the `sysdig_image_scan` key.
We'll switch to skipping over duplicates and gather information about whether skipping is in fact the right choice.


## Commits

- skip creation and gather info about duplicates
- update snapshots
