### PR TITLE
INT-2814 - Ingest Kubernetes configurations from Sysdig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added support for ingesting the following **new** entities:
+
+| Resources | Entity `_type`   | Entity `_class` |
+| --------- | ---------------- | --------------- |
+| Agent     | `sysdig_agent`   | `Scanner`       |
+| Cluster   | `sysdig_cluster` | `Cluster`       |
+
+- Added support for ingesting the following **new** relationships:
+
+| Source Entity `_type` | Relationship `_class` | Target Entity `_type` |
+| --------------------- | --------------------- | --------------------- |
+| `sysdig_agent`        | **SCANS**             | `sysdig_cluster`      |
+
 ## 1.0.1 - 2022-11-14
 
 ### Fixed
@@ -31,6 +46,8 @@ and this project adheres to
 | --------- | ---------------- | --------------- |
 | Finding   | `sysdig_finding` | `Finding`       |
 | Scanner   | `sysdig_scanner` | `Service`       |
+| Agent     | `sysdig_agent`   | `Scanner`       |
+| Cluster   | `sysdig_cluster` | `Cluster`       |
 
 - Added support for ingesting the following **new** relationships:
 
@@ -38,6 +55,7 @@ and this project adheres to
 | --------------------- | --------------------- | --------------------- |
 | `sysdig_image_scan`   | **IDENTIFIED**        | `sysdig_finding`      |
 | `sysdig_scanner`      | **PERFORMED**         | `sysdig_image_scan`   |
+| `sysdig_agent`        | **SCANS**             | `sysdig_cluster`      |
 
 - Added support for ingesting the following **new** mapped relationships:
 

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -84,6 +84,8 @@ The following entities are created:
 | Resources  | Entity `_type`      | Entity `_class` |
 | ---------- | ------------------- | --------------- |
 | Account    | `sysdig_account`    | `Account`       |
+| Agent      | `sysdig_agent`      | `Scanner`       |
+| Cluster    | `sysdig_cluster`    | `Cluster`       |
 | Finding    | `sysdig_finding`    | `Finding`       |
 | Image Scan | `sysdig_image_scan` | `Assessment`    |
 | Scanner    | `sysdig_scanner`    | `Service`       |
@@ -96,10 +98,13 @@ The following relationships are created:
 
 | Source Entity `_type` | Relationship `_class` | Target Entity `_type` |
 | --------------------- | --------------------- | --------------------- |
+| `sysdig_account`      | **HAS**               | `sysdig_agent`        |
+| `sysdig_account`      | **HAS**               | `sysdig_cluster`      |
 | `sysdig_account`      | **HAS**               | `sysdig_image_scan`   |
 | `sysdig_account`      | **HAS**               | `sysdig_scanner`      |
 | `sysdig_account`      | **HAS**               | `sysdig_team`         |
 | `sysdig_account`      | **HAS**               | `sysdig_user`         |
+| `sysdig_agent`        | **SCANS**             | `sysdig_cluster`      |
 | `sysdig_image_scan`   | **IDENTIFIED**        | `sysdig_finding`      |
 | `sysdig_scanner`      | **PERFORMED**         | `sysdig_image_scan`   |
 | `sysdig_team`         | **HAS**               | `sysdig_user`         |

--- a/docs/spec/src/agents/index.ts
+++ b/docs/spec/src/agents/index.ts
@@ -1,0 +1,30 @@
+import { RelationshipClass, StepSpec } from '@jupiterone/integration-sdk-core';
+import { IntegrationConfig } from '../../../../src/config';
+
+export const agentSpec: StepSpec<IntegrationConfig>[] = [
+  {
+    /**
+     * ENDPOINT: /api/cloud/v2/dataSources/agents
+     * PATTERN: Fetch Entities
+     */
+    id: 'fetch-agents',
+    name: 'Fetch Agents',
+    entities: [
+      {
+        resourceName: 'Agent',
+        _type: 'sysdig_agent',
+        _class: ['Scanner'],
+      },
+    ],
+    relationships: [
+      {
+        _type: 'sysdig_account_has_agent',
+        sourceType: 'sysdig_account',
+        _class: RelationshipClass.HAS,
+        targetType: 'sysdig_agent',
+      },
+    ],
+    dependsOn: ['fetch-account'],
+    implemented: true,
+  },
+];

--- a/docs/spec/src/clusters/index.ts
+++ b/docs/spec/src/clusters/index.ts
@@ -1,0 +1,49 @@
+import { RelationshipClass, StepSpec } from '@jupiterone/integration-sdk-core';
+import { IntegrationConfig } from '../../../../src/config';
+
+export const clusterSpec: StepSpec<IntegrationConfig>[] = [
+  {
+    /**
+     * ENDPOINT: /api/cloud/v2/dataSources/clusters
+     * PATTERN: Fetch Entities
+     */
+    id: 'fetch-clusters',
+    name: 'Fetch Clusters',
+    entities: [
+      {
+        resourceName: 'Cluster',
+        _type: 'sysdig_cluster',
+        _class: ['Cluster'],
+      },
+    ],
+    relationships: [
+      {
+        _type: 'sysdig_account_has_cluster',
+        sourceType: 'sysdig_account',
+        _class: RelationshipClass.HAS,
+        targetType: 'sysdig_cluster',
+      },
+    ],
+    dependsOn: ['fetch-account'],
+    implemented: true,
+  },
+  {
+    /**
+     * ENDPOINT: n/a
+     * PATTERN: Build Child Relationships
+     */
+    id: 'build-cluster-and-agent-relationship',
+    name: 'Build Cluster and Agent Relationship',
+    entities: [],
+    relationships: [
+      {
+        _type: 'sysdig_agent_scans_cluster',
+        sourceType: 'sysdig_agent',
+        _class: RelationshipClass.SCANS,
+        targetType: 'sysdig_cluster',
+      },
+    ],
+    dependsOn: ['fetch-agents', 'fetch-clusters'],
+    implemented: true,
+  },
+];

--- a/docs/spec/src/index.ts
+++ b/docs/spec/src/index.ts
@@ -2,6 +2,8 @@ import { IntegrationSpecConfig } from '@jupiterone/integration-sdk-core';
 
 import { IntegrationConfig } from '../../../src/config';
 import { accountSpec } from './account';
+import { agentSpec } from './agents';
+import { clusterSpec } from './clusters';
 import { scannerSpec } from './scanner';
 import { scansSpec } from './scans';
 import { teamsSpec } from './teams';
@@ -14,5 +16,7 @@ export const invocationConfig: IntegrationSpecConfig<IntegrationConfig> = {
     ...scansSpec,
     ...teamsSpec,
     ...usersSpec,
+    ...agentSpec,
+    ...clusterSpec,
   ],
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,6 +13,8 @@ import {
   PaginatedUsers,
   PaginatedVulnerabilities,
   SysdigAccount,
+  SysdigAgent,
+  SysdigCluster,
   SysdigResult,
   SysdigResultResponse,
   SysdigTeam,
@@ -192,6 +194,44 @@ export class APIClient {
         }
       }
     } while ((offset + 1) * this.paginateEntitiesPerPage < body.metadata.total);
+  }
+
+  /**
+   * Iterates each cluster resource in the provider.
+   *
+   * @param pageIteratee receives each resource to produce entities/relationships
+   */
+  public async iterateClusters(
+    pageIteratee: ResourceIteratee<SysdigCluster>,
+  ): Promise<void> {
+    const endpoint = this.withBaseUri(`api/cloud/v2/dataSources/clusters`);
+    const response = await this.request(endpoint, 'GET');
+    const clusters = await response.json();
+
+    if (clusters) {
+      for (const cluster of clusters) {
+        await pageIteratee(cluster);
+      }
+    }
+  }
+
+  /**
+   * Iterates each cluster resource in the provider.
+   *
+   * @param pageIteratee receives each resource to produce entities/relationships
+   */
+  public async iterateAgents(
+    pageIteratee: ResourceIteratee<SysdigAgent>,
+  ): Promise<void> {
+    const endpoint = this.withBaseUri(`api/cloud/v2/dataSources/agents`);
+    const response = await this.request(endpoint, 'GET');
+    const body = await response.json();
+
+    if (body.details) {
+      for (const agent of body.details) {
+        await pageIteratee(agent);
+      }
+    }
   }
 
   /**

--- a/src/steps/agents/__recordings__/fetch-agents_730038084/recording.har
+++ b/src/steps/agents/__recordings__/fetch-agents_730038084/recording.har
@@ -1,0 +1,242 @@
+{
+  "log": {
+    "_recordingName": "fetch-agents",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "a8b64a7f911706ca16ad0d13033c05a9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "app.us4.sysdig.com"
+            }
+          ],
+          "headersSize": 285,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.us4.sysdig.com/api/user/me"
+        },
+        "response": {
+          "bodySize": 1787,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1787,
+            "text": "{\"user\":{\"termsAndConditions\":true,\"timezone\":\"+00:00\",\"pictureUrl\":\"http://www.gravatar.com/avatar/ba5b87ffa4527a556b5f6da95fe36fe5\",\"customerSettings\":{\"sysdig\":{\"enabled\":false,\"enabledSSE\":false,\"buckets\":[]},\"plan\":{\"maxAgents\":0,\"onDemandAgents\":0,\"maxTeams\":-1,\"timelines\":[{\"from\":null,\"to\":null,\"sampling\":10000000},{\"from\":null,\"to\":null,\"sampling\":60000000},{\"from\":null,\"to\":null,\"sampling\":600000000},{\"from\":null,\"to\":null,\"sampling\":3600000000},{\"from\":null,\"to\":null,\"sampling\":86400000000}],\"metricsSettings\":{\"enforce\":false,\"showExperimentals\":false,\"limits\":{\"jmx\":500,\"statsd\":1000,\"appCheck\":500,\"prometheus\":8000,\"prometheusPerProcess\":500,\"connections\":80,\"progAggregationCount\":12,\"appCheckAggregationCount\":12,\"promMetricsWeight\":0.0,\"topFilesCount\":10,\"topDevicesCount\":10,\"hostServerPorts\":10,\"containerServerPorts\":5,\"limitKubernetesResources\":false,\"kubernetesPods\":10000,\"kubernetesJobs\":10000,\"containerDensity\":200,\"meerkatSuited\":true},\"enforceAgentAggregation\":true,\"enablePromCalculatedIngestion\":false,\"enablePromScrapeV2\":true,\"enableGlobalK8sAllPodContainers\":false},\"secureEnabled\":true,\"monitorEnabled\":false,\"allocatedAgentsCount\":0,\"subscriptionState\":\"trial_ended\",\"paymentsIntegrationId\":{\"id\":\"not present\",\"ttl\":{\"ttl\":36}},\"pricingPlan\":\"pro\",\"indirectCustomer\":false,\"trialPlanName\":\"secure-enterprise-standard-monthly\",\"partner\":\"Direct\",\"trialEndDate\":1664383443236,\"subscriptionVersion\":2,\"migratedToV2Direct\":false,\"overageAssessmentEligible\":false},\"environment\":{}},\"customer\":{\"id\":5001686,\"name\":null,\"accessKey\":\"1be2fe7d-f00f-4513-9a15-1384c35d8497\",\"externalId\":\"fbd8b3fc-781c-4e7f-afac-a2ee9309f4c9\",\"dateCreated\":1661791442836},\"oauth\":false,\"agentInstallParams\":{\"accessKey\":\"1be2fe7d-f00f-4513-9a15-1384c35d8497\",\"collectorAddress\":\"ingest.us4.sysdig.com\",\"collectorPort\":6443,\"checkCertificate\":true,\"sslEnabled\":true},\"remoteWriteParams\":{\"serverAddress\":\"app.us4.sysdig.com\"},\"properties\":{\"has_been_invited\":false},\"resetPassword\":false,\"additionalRoles\":[],\"teamRoles\":[{\"teamId\":50006625,\"teamName\":\"Monitor Operations\",\"teamTheme\":\"#7BB0B2\",\"userId\":50003375,\"userName\":\"stefan.virag@contractor.jupiterone.com\",\"role\":\"ROLE_TEAM_MANAGER\",\"admin\":true},{\"teamId\":50006626,\"teamName\":\"Secure Operations\",\"teamTheme\":\"#7BB0B2\",\"userId\":50003375,\"userName\":\"stefan.virag@contractor.jupiterone.com\",\"role\":\"ROLE_TEAM_MANAGER\",\"admin\":true}],\"lastUpdated\":1667330352360,\"dateActivated\":1661791669709,\"accessKey\":\"1be2fe7d-f00f-4513-9a15-1384c35d8497\",\"intercomUserIdHash\":\"7941192844d448aedd650df4bd26799efd5fca275a1f1eef775ee67b6cf061ad\",\"uniqueIntercomUserId\":\"50003375.fbd8b3fc-781c-4e7f-afac-a2ee9309f4c9\",\"currentTeam\":50006626,\"name\":\"stefan.virag@contractor.jupiterone.com\",\"id\":50003375,\"version\":2,\"enabled\":true,\"lastSeenOnSecure\":1667330352360,\"products\":[\"SDC\",\"SDS\"],\"status\":\"confirmed\",\"firstName\":\"Stefan\",\"lastName\":\"Virag\",\"systemRole\":\"ROLE_CUSTOMER\",\"username\":\"stefan.virag@contractor.jupiterone.com\",\"dateCreated\":1661791442936}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "INGRESSCOOKIEAPI",
+              "path": "/",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 01 Nov 2022 19:57:23 GMT"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Accept-Encoding, User-Agent"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store, max-age=0, must-revalidate"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15768000"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 498,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-11-01T19:57:23.435Z",
+        "time": 603,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 603
+        }
+      },
+      {
+        "_id": "ec78b89f0b38647eb4909d5501c1ac74",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "app.us4.sysdig.com"
+            }
+          ],
+          "headersSize": 305,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.us4.sysdig.com/api/cloud/v2/dataSources/agents"
+        },
+        "response": {
+          "bodySize": 317,
+          "content": {
+            "mimeType": "application/json",
+            "size": 317,
+            "text": "{\"agentStats\":{\"almostOutOfDateCount\":0,\"outOfDateCount\":0,\"disconnectedCount\":1,\"healthyCount\":0,\"neverConnected\":0,\"unknown\":0},\"details\":[{\"agentStatus\":\"Disconnected\",\"agentVersion\":\"12.8.1\",\"labels\":{\"hostname\":\"creativice-vm-debian-1\",\"machineId\":\"08:00:27:f2:12:67\"},\"moreOptions\":{\"agentConnectString\":\"\"}}]}\n"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "INGRESSCOOKIEAPI",
+              "path": "/",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 01 Nov 2022 19:57:24 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "317"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15768000"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 245,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-11-01T19:57:24.127Z",
+        "time": 578,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 578
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/agents/__snapshots__/converters.test.ts.snap
+++ b/src/steps/agents/__snapshots__/converters.test.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#createAgentEntity should convert to entity 1`] = `
+Object {
+  "_class": Array [
+    "Scanner",
+  ],
+  "_key": "sysdig-agent:gcp-gke-sysdig-cluster-default-pool-12345678-6l1s",
+  "_rawData": Array [
+    Object {
+      "name": "default",
+      "rawData": Object {
+        "agentIssues": Array [
+          Object {
+            "explanation": "Agent was never connected.",
+            "fix": "review agent logs and/or network connectivity",
+            "reason": "Never Connected",
+            "status": "Never Connected",
+          },
+        ],
+        "agentStatus": "Never Connected",
+        "clusterName": "sysdig-cluster",
+        "labels": Object {
+          "accountId": "1234567890",
+          "hostname": "gke-sysdig-cluster-default-pool-12345678-6l1s",
+          "machineId": "",
+          "provider": "gcp",
+        },
+        "moreOptions": Object {
+          "agentConnectString": "agent connect string",
+        },
+      },
+    },
+  ],
+  "_type": "sysdig_agent",
+  "accountId": "1234567890",
+  "agentConnectString": "agent connect string",
+  "agentStatus": "Never Connected",
+  "category": Array [
+    "application",
+  ],
+  "clusterName": "sysdig-cluster",
+  "createdOn": undefined,
+  "displayName": "gke-sysdig-cluster-default-pool-12345678-6l1s",
+  "hostname": "gke-sysdig-cluster-default-pool-12345678-6l1s",
+  "machineId": "",
+  "name": "gke-sysdig-cluster-default-pool-12345678-6l1s",
+  "provider": "gcp",
+}
+`;

--- a/src/steps/agents/converter.ts
+++ b/src/steps/agents/converter.ts
@@ -1,0 +1,29 @@
+import {
+  createIntegrationEntity,
+  Entity,
+} from '@jupiterone/integration-sdk-core';
+
+import { SysdigAgent } from '../../types';
+import { Entities } from '../constants';
+
+export function createAgentEntity(data: SysdigAgent): Entity {
+  return createIntegrationEntity({
+    entityData: {
+      source: data,
+      assign: {
+        _key: `sysdig-agent:${data.labels.provider}-${data.labels.hostname}`,
+        _type: Entities.AGENT._type,
+        _class: Entities.AGENT._class,
+        name: data.labels.hostname,
+        agentStatus: data.agentStatus,
+        clusterName: data.clusterName,
+        accountId: data.labels.accountId,
+        hostname: data.labels.hostname,
+        machineId: data.labels.machineId,
+        provider: data.labels.provider,
+        agentConnectString: data.moreOptions.agentConnectString,
+        category: ['application'],
+      },
+    },
+  });
+}

--- a/src/steps/agents/converters.test.ts
+++ b/src/steps/agents/converters.test.ts
@@ -1,0 +1,8 @@
+import { getMockAgent } from '../../../test/mocks';
+import { createAgentEntity } from './converter';
+
+describe('#createAgentEntity', () => {
+  test('should convert to entity', () => {
+    expect(createAgentEntity(getMockAgent())).toMatchSnapshot();
+  });
+});

--- a/src/steps/agents/index.test.ts
+++ b/src/steps/agents/index.test.ts
@@ -1,0 +1,24 @@
+import {
+  executeStepWithDependencies,
+  Recording,
+} from '@jupiterone/integration-sdk-testing';
+import { buildStepTestConfigForStep } from '../../../test/config';
+import { setupProjectRecording } from '../../../test/recording';
+import { Steps } from '../constants';
+
+let recording: Recording;
+
+afterEach(async () => {
+  await recording.stop();
+});
+
+test('#fetchAgents', async () => {
+  recording = setupProjectRecording({
+    directory: __dirname,
+    name: 'fetch-agents',
+  });
+
+  const stepConfig = buildStepTestConfigForStep(Steps.AGENTS);
+  const stepResult = await executeStepWithDependencies(stepConfig);
+  expect(stepResult).toMatchStepMetadata(stepConfig);
+});

--- a/src/steps/agents/index.ts
+++ b/src/steps/agents/index.ts
@@ -1,0 +1,44 @@
+import {
+  createDirectRelationship,
+  Entity,
+  IntegrationStep,
+  IntegrationStepExecutionContext,
+  RelationshipClass,
+} from '@jupiterone/integration-sdk-core';
+
+import { createAPIClient } from '../../client';
+import { IntegrationConfig } from '../../config';
+import { ACCOUNT_ENTITY_KEY } from '../account';
+import { Steps, Entities, Relationships } from '../constants';
+import { createAgentEntity } from './converter';
+
+export async function fetchAgents({
+  instance,
+  jobState,
+}: IntegrationStepExecutionContext<IntegrationConfig>) {
+  const apiClient = createAPIClient(instance.config);
+  const accountEntity = (await jobState.getData(ACCOUNT_ENTITY_KEY)) as Entity;
+
+  await apiClient.iterateAgents(async (agent) => {
+    const agentEntity = await jobState.addEntity(createAgentEntity(agent));
+
+    await jobState.addRelationship(
+      createDirectRelationship({
+        _class: RelationshipClass.HAS,
+        from: accountEntity,
+        to: agentEntity,
+      }),
+    );
+  });
+}
+
+export const agentSteps: IntegrationStep<IntegrationConfig>[] = [
+  {
+    id: Steps.AGENTS,
+    name: 'Fetch Agents',
+    entities: [Entities.AGENT],
+    relationships: [Relationships.ACCOUNT_HAS_AGENT],
+    dependsOn: [Steps.ACCOUNT],
+    executionHandler: fetchAgents,
+  },
+];

--- a/src/steps/clusters/__recordings__/build-cluster-agent-relationship_3739408733/recording.har
+++ b/src/steps/clusters/__recordings__/build-cluster-agent-relationship_3739408733/recording.har
@@ -1,0 +1,350 @@
+{
+  "log": {
+    "_recordingName": "build-cluster-agent-relationship",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "a8b64a7f911706ca16ad0d13033c05a9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "app.us4.sysdig.com"
+            }
+          ],
+          "headersSize": 285,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.us4.sysdig.com/api/user/me"
+        },
+        "response": {
+          "bodySize": 1791,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1791,
+            "text": "{\"user\":{\"termsAndConditions\":true,\"timezone\":\"+00:00\",\"pictureUrl\":\"http://www.gravatar.com/avatar/db625e12dbc01a7c18a1f8176c30c8ad\",\"customerSettings\":{\"sysdig\":{\"enabled\":false,\"enabledSSE\":false,\"buckets\":[]},\"plan\":{\"maxAgents\":15,\"onDemandAgents\":0,\"maxTeams\":-1,\"timelines\":[{\"from\":null,\"to\":null,\"sampling\":10000000},{\"from\":null,\"to\":null,\"sampling\":60000000},{\"from\":null,\"to\":null,\"sampling\":600000000},{\"from\":null,\"to\":null,\"sampling\":3600000000},{\"from\":null,\"to\":null,\"sampling\":86400000000}],\"metricsSettings\":{\"enforce\":false,\"showExperimentals\":false,\"limits\":{\"jmx\":500,\"statsd\":1000,\"appCheck\":500,\"prometheus\":8000,\"prometheusPerProcess\":500,\"connections\":80,\"progAggregationCount\":12,\"appCheckAggregationCount\":12,\"promMetricsWeight\":0.0,\"topFilesCount\":10,\"topDevicesCount\":10,\"hostServerPorts\":10,\"containerServerPorts\":5,\"limitKubernetesResources\":false,\"kubernetesPods\":10000,\"kubernetesJobs\":10000,\"containerDensity\":200,\"meerkatSuited\":true},\"enforceAgentAggregation\":true,\"enablePromCalculatedIngestion\":false,\"enablePromScrapeV2\":true,\"enableGlobalK8sAllPodContainers\":false},\"secureEnabled\":true,\"monitorEnabled\":true,\"allocatedAgentsCount\":15,\"subscriptionState\":\"trialing\",\"paymentsIntegrationId\":{\"id\":\"not present\",\"ttl\":{\"ttl\":50}},\"pricingPlan\":\"pro\",\"indirectCustomer\":false,\"trialPlanName\":\"platform-enterprise-standard-monthly\",\"partner\":\"Direct\",\"trialEndDate\":1669014412815,\"subscriptionVersion\":2,\"migratedToV2Direct\":false,\"overageAssessmentEligible\":false},\"environment\":{}},\"customer\":{\"id\":5002012,\"name\":null,\"accessKey\":\"c96722ec-6cab-4009-989e-2585d1cc0ddc\",\"externalId\":\"5b5d85e9-97d6-4ed8-bcd2-8a5ef159ffc1\",\"dateCreated\":1666422412365},\"oauth\":false,\"agentInstallParams\":{\"accessKey\":\"c96722ec-6cab-4009-989e-2585d1cc0ddc\",\"collectorAddress\":\"ingest.us4.sysdig.com\",\"collectorPort\":6443,\"checkCertificate\":true,\"sslEnabled\":true},\"remoteWriteParams\":{\"serverAddress\":\"app.us4.sysdig.com\"},\"properties\":{\"has_been_invited\":false},\"resetPassword\":false,\"additionalRoles\":[],\"teamRoles\":[{\"teamId\":50007301,\"teamName\":\"Secure Operations\",\"teamTheme\":\"#7BB0B2\",\"userId\":50003902,\"userName\":\"paul.ilaga@creativice.com\",\"role\":\"ROLE_TEAM_MANAGER\",\"admin\":true},{\"teamId\":50007300,\"teamName\":\"Monitor Operations\",\"teamTheme\":\"#7BB0B2\",\"userId\":50003902,\"userName\":\"paul.ilaga@creativice.com\",\"role\":\"ROLE_TEAM_MANAGER\",\"admin\":true}],\"lastUpdated\":1666594263876,\"dateActivated\":1666422628222,\"accessKey\":\"c96722ec-6cab-4009-989e-2585d1cc0ddc\",\"intercomUserIdHash\":\"d4a56fa25f1602197e21715aa94abbe7a87cd593a9b72e6c3bf7d694599ea317\",\"uniqueIntercomUserId\":\"50003902.5b5d85e9-97d6-4ed8-bcd2-8a5ef159ffc1\",\"currentTeam\":50007301,\"name\":\"paul.ilaga@creativice.com\",\"id\":50003902,\"version\":2,\"enabled\":true,\"firstName\":\"Paul\",\"lastName\":\"Ilaga\",\"systemRole\":\"ROLE_CUSTOMER\",\"products\":[\"SDS\",\"SDC\"],\"username\":\"paul.ilaga@creativice.com\",\"status\":\"confirmed\",\"lastSeen\":1666586763345,\"dateCreated\":1666422412473,\"lastSeenOnSecure\":1666594263876}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "INGRESSCOOKIEAPI",
+              "path": "/",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 24 Oct 2022 07:32:04 GMT"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Accept-Encoding, User-Agent"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store, max-age=0, must-revalidate"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15768000"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 498,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-10-24T07:32:04.392Z",
+        "time": 631,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 631
+        }
+      },
+      {
+        "_id": "ec78b89f0b38647eb4909d5501c1ac74",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "app.us4.sysdig.com"
+            }
+          ],
+          "headersSize": 305,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.us4.sysdig.com/api/cloud/v2/dataSources/agents"
+        },
+        "response": {
+          "bodySize": 2429,
+          "content": {
+            "mimeType": "application/json",
+            "size": 2429,
+            "text": "{\"agentStats\":{\"almostOutOfDateCount\":0,\"outOfDateCount\":0,\"disconnectedCount\":0,\"healthyCount\":0,\"neverConnected\":3,\"unknown\":0},\"details\":[{\"agentStatus\":\"Never Connected\",\"agentIssues\":[{\"reason\":\"Never Connected\",\"status\":\"Never Connected\",\"explanation\":\"Agent was never connected.\",\"fix\":\"review agent logs and/or network connectivity\"}],\"clusterName\":\"sysdig-cluster\",\"labels\":{\"accountId\":\"3052281098\",\"hostname\":\"gke-sysdig-cluster-default-pool-0b0dfbff-6l1s\",\"machineId\":\"\",\"provider\":\"gcp\"},\"moreOptions\":{\"agentConnectString\":\"gcloud container clusters get-credentials sysdig-cluster --zone=us-central1-c \\u0026\\u0026 curl -s https://download.sysdig.com/stable/install-agent-kubernetes | sudo bash -s -- --access_key --collector ingest.us4.sysdig.com --collector_port 6443 --cluster_name sysdig-cluster --nodeanalyzer --api_endpoint app.us4.sysdig.com\"}},{\"agentStatus\":\"Never Connected\",\"agentIssues\":[{\"reason\":\"Never Connected\",\"status\":\"Never Connected\",\"explanation\":\"Agent was never connected.\",\"fix\":\"review agent logs and/or network connectivity\"}],\"clusterName\":\"sysdig-cluster\",\"labels\":{\"accountId\":\"3052281098\",\"hostname\":\"gke-sysdig-cluster-default-pool-0b0dfbff-8f33\",\"machineId\":\"\",\"provider\":\"gcp\"},\"moreOptions\":{\"agentConnectString\":\"gcloud container clusters get-credentials sysdig-cluster --zone=us-central1-c \\u0026\\u0026 curl -s https://download.sysdig.com/stable/install-agent-kubernetes | sudo bash -s -- --access_key --collector ingest.us4.sysdig.com --collector_port 6443 --cluster_name sysdig-cluster --nodeanalyzer --api_endpoint app.us4.sysdig.com\"}},{\"agentStatus\":\"Never Connected\",\"agentIssues\":[{\"reason\":\"Never Connected\",\"status\":\"Never Connected\",\"explanation\":\"Agent was never connected.\",\"fix\":\"review agent logs and/or network connectivity\"}],\"clusterName\":\"sysdig-cluster\",\"labels\":{\"accountId\":\"3052281098\",\"hostname\":\"gke-sysdig-cluster-default-pool-0b0dfbff-bb6l\",\"machineId\":\"\",\"provider\":\"gcp\"},\"moreOptions\":{\"agentConnectString\":\"gcloud container clusters get-credentials sysdig-cluster --zone=us-central1-c \\u0026\\u0026 curl -s https://download.sysdig.com/stable/install-agent-kubernetes | sudo bash -s -- --access_key --collector ingest.us4.sysdig.com --collector_port 6443 --cluster_name sysdig-cluster --nodeanalyzer --api_endpoint app.us4.sysdig.com\"}}]}\n"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "INGRESSCOOKIEAPI",
+              "path": "/",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 24 Oct 2022 07:32:05 GMT"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15768000"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 252,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-10-24T07:32:05.053Z",
+        "time": 557,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 557
+        }
+      },
+      {
+        "_id": "f0bad22a42bcb9cf5b57afe3ba22e9da",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "app.us4.sysdig.com"
+            }
+          ],
+          "headersSize": 307,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.us4.sysdig.com/api/cloud/v2/dataSources/clusters"
+        },
+        "response": {
+          "bodySize": 648,
+          "content": {
+            "mimeType": "application/json",
+            "size": 648,
+            "text": "[{\"customerID\":5002012,\"accountID\":\"3052281098\",\"provider\":\"gcp\",\"name\":\"sysdig-cluster\",\"region\":\"us-central1\",\"zone\":\"us-central1-c\",\"agentConnected\":false,\"createdAt\":\"2022-10-22T09:40:26Z\",\"nodeCount\":1,\"clusterResourceGroup\":\"\",\"version\":\"1.23.8-gke.1900\",\"agentConnectString\":\"gcloud container clusters get-credentials sysdig-cluster --zone=us-central1-c \\u0026\\u0026 curl -s https://download.sysdig.com/stable/install-agent-kubernetes | sudo bash -s -- --access_key --collector ingest.us4.sysdig.com --collector_port 6443 --cluster_name sysdig-cluster --nodeanalyzer --api_endpoint app.us4.sysdig.com\"}]\n"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "INGRESSCOOKIEAPI",
+              "path": "/",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 24 Oct 2022 07:32:06 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "648"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15768000"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 245,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-10-24T07:32:05.626Z",
+        "time": 475,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 475
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/clusters/__recordings__/fetch-clusters_2130475341/recording.har
+++ b/src/steps/clusters/__recordings__/fetch-clusters_2130475341/recording.har
@@ -1,0 +1,242 @@
+{
+  "log": {
+    "_recordingName": "fetch-clusters",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "a8b64a7f911706ca16ad0d13033c05a9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "app.us4.sysdig.com"
+            }
+          ],
+          "headersSize": 285,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.us4.sysdig.com/api/user/me"
+        },
+        "response": {
+          "bodySize": 1791,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1791,
+            "text": "{\"user\":{\"termsAndConditions\":true,\"timezone\":\"+00:00\",\"pictureUrl\":\"http://www.gravatar.com/avatar/db625e12dbc01a7c18a1f8176c30c8ad\",\"customerSettings\":{\"sysdig\":{\"enabled\":false,\"enabledSSE\":false,\"buckets\":[]},\"plan\":{\"maxAgents\":15,\"onDemandAgents\":0,\"maxTeams\":-1,\"timelines\":[{\"from\":null,\"to\":null,\"sampling\":10000000},{\"from\":null,\"to\":null,\"sampling\":60000000},{\"from\":null,\"to\":null,\"sampling\":600000000},{\"from\":null,\"to\":null,\"sampling\":3600000000},{\"from\":null,\"to\":null,\"sampling\":86400000000}],\"metricsSettings\":{\"enforce\":false,\"showExperimentals\":false,\"limits\":{\"jmx\":500,\"statsd\":1000,\"appCheck\":500,\"prometheus\":8000,\"prometheusPerProcess\":500,\"connections\":80,\"progAggregationCount\":12,\"appCheckAggregationCount\":12,\"promMetricsWeight\":0.0,\"topFilesCount\":10,\"topDevicesCount\":10,\"hostServerPorts\":10,\"containerServerPorts\":5,\"limitKubernetesResources\":false,\"kubernetesPods\":10000,\"kubernetesJobs\":10000,\"containerDensity\":200,\"meerkatSuited\":true},\"enforceAgentAggregation\":true,\"enablePromCalculatedIngestion\":false,\"enablePromScrapeV2\":true,\"enableGlobalK8sAllPodContainers\":false},\"secureEnabled\":true,\"monitorEnabled\":true,\"allocatedAgentsCount\":15,\"subscriptionState\":\"trialing\",\"paymentsIntegrationId\":{\"id\":\"not present\",\"ttl\":{\"ttl\":50}},\"pricingPlan\":\"pro\",\"indirectCustomer\":false,\"trialPlanName\":\"platform-enterprise-standard-monthly\",\"partner\":\"Direct\",\"trialEndDate\":1669014412815,\"subscriptionVersion\":2,\"migratedToV2Direct\":false,\"overageAssessmentEligible\":false},\"environment\":{}},\"customer\":{\"id\":5002012,\"name\":null,\"accessKey\":\"c96722ec-6cab-4009-989e-2585d1cc0ddc\",\"externalId\":\"5b5d85e9-97d6-4ed8-bcd2-8a5ef159ffc1\",\"dateCreated\":1666422412365},\"oauth\":false,\"agentInstallParams\":{\"accessKey\":\"c96722ec-6cab-4009-989e-2585d1cc0ddc\",\"collectorAddress\":\"ingest.us4.sysdig.com\",\"collectorPort\":6443,\"checkCertificate\":true,\"sslEnabled\":true},\"remoteWriteParams\":{\"serverAddress\":\"app.us4.sysdig.com\"},\"properties\":{\"has_been_invited\":false},\"resetPassword\":false,\"additionalRoles\":[],\"teamRoles\":[{\"teamId\":50007301,\"teamName\":\"Secure Operations\",\"teamTheme\":\"#7BB0B2\",\"userId\":50003902,\"userName\":\"paul.ilaga@creativice.com\",\"role\":\"ROLE_TEAM_MANAGER\",\"admin\":true},{\"teamId\":50007300,\"teamName\":\"Monitor Operations\",\"teamTheme\":\"#7BB0B2\",\"userId\":50003902,\"userName\":\"paul.ilaga@creativice.com\",\"role\":\"ROLE_TEAM_MANAGER\",\"admin\":true}],\"lastUpdated\":1666594263876,\"dateActivated\":1666422628222,\"accessKey\":\"c96722ec-6cab-4009-989e-2585d1cc0ddc\",\"intercomUserIdHash\":\"d4a56fa25f1602197e21715aa94abbe7a87cd593a9b72e6c3bf7d694599ea317\",\"uniqueIntercomUserId\":\"50003902.5b5d85e9-97d6-4ed8-bcd2-8a5ef159ffc1\",\"currentTeam\":50007301,\"name\":\"paul.ilaga@creativice.com\",\"id\":50003902,\"version\":2,\"enabled\":true,\"firstName\":\"Paul\",\"lastName\":\"Ilaga\",\"systemRole\":\"ROLE_CUSTOMER\",\"lastSeen\":1666586763345,\"status\":\"confirmed\",\"products\":[\"SDS\",\"SDC\"],\"username\":\"paul.ilaga@creativice.com\",\"dateCreated\":1666422412473,\"lastSeenOnSecure\":1666594263876}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "INGRESSCOOKIEAPI",
+              "path": "/",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 24 Oct 2022 07:09:04 GMT"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Accept-Encoding, User-Agent"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store, max-age=0, must-revalidate"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15768000"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 498,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-10-24T07:09:03.630Z",
+        "time": 568,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 568
+        }
+      },
+      {
+        "_id": "f0bad22a42bcb9cf5b57afe3ba22e9da",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "app.us4.sysdig.com"
+            }
+          ],
+          "headersSize": 307,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://app.us4.sysdig.com/api/cloud/v2/dataSources/clusters"
+        },
+        "response": {
+          "bodySize": 648,
+          "content": {
+            "mimeType": "application/json",
+            "size": 648,
+            "text": "[{\"customerID\":5002012,\"accountID\":\"3052281098\",\"provider\":\"gcp\",\"name\":\"sysdig-cluster\",\"region\":\"us-central1\",\"zone\":\"us-central1-c\",\"agentConnected\":false,\"createdAt\":\"2022-10-22T09:40:26Z\",\"nodeCount\":1,\"clusterResourceGroup\":\"\",\"version\":\"1.23.8-gke.1900\",\"agentConnectString\":\"gcloud container clusters get-credentials sysdig-cluster --zone=us-central1-c \\u0026\\u0026 curl -s https://download.sysdig.com/stable/install-agent-kubernetes | sudo bash -s -- --access_key --collector ingest.us4.sysdig.com --collector_port 6443 --cluster_name sysdig-cluster --nodeanalyzer --api_endpoint app.us4.sysdig.com\"}]\n"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "INGRESSCOOKIEAPI",
+              "path": "/",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 24 Oct 2022 07:09:04 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "648"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15768000"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 245,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-10-24T07:09:04.251Z",
+        "time": 539,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 539
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/clusters/__snapshots__/converters.test.ts.snap
+++ b/src/steps/clusters/__snapshots__/converters.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#createClusterEntity should convert to entity 1`] = `
+Object {
+  "_class": Array [
+    "Cluster",
+  ],
+  "_key": "sysdig-cluster:gcp-sysdig-cluster",
+  "_rawData": Array [
+    Object {
+      "name": "default",
+      "rawData": Object {
+        "accountID": "30521231234",
+        "agentConnected": false,
+        "clusterResourceGroup": "",
+        "createdAt": "2002-10-22T09:22:26Z",
+        "customerID": 123456,
+        "name": "sysdig-cluster",
+        "nodeCount": 1,
+        "provider": "gcp",
+        "region": "us-central1",
+        "version": "1.23.8-gke.1900",
+        "zone": "us-central1-c",
+      },
+    },
+  ],
+  "_type": "sysdig_cluster",
+  "accountId": "30521231234",
+  "agentConnected": false,
+  "clusterResourceGroup": "",
+  "createdOn": 1035278546000,
+  "customerId": 123456,
+  "displayName": "sysdig-cluster",
+  "name": "sysdig-cluster",
+  "nodeCount": 1,
+  "provider": "gcp",
+  "region": "us-central1",
+  "version": "1.23.8-gke.1900",
+  "zone": "us-central1-c",
+}
+`;

--- a/src/steps/clusters/converter.ts
+++ b/src/steps/clusters/converter.ts
@@ -1,0 +1,40 @@
+import {
+  createIntegrationEntity,
+  Entity,
+  parseTimePropertyValue,
+} from '@jupiterone/integration-sdk-core';
+
+import { SysdigCluster } from '../../types';
+import { Entities } from '../constants';
+
+export function getClusterKey(provider: string, name: string) {
+  return `sysdig-cluster:${provider}-${name}`;
+}
+
+export function createClusterEntity(data: SysdigCluster): Entity {
+  const { agentConnectString, ...cluster } = data;
+
+  return createIntegrationEntity({
+    entityData: {
+      source: {
+        ...cluster,
+      },
+      assign: {
+        _key: getClusterKey(data.provider, data.name),
+        _type: Entities.CLUSTER._type,
+        _class: Entities.CLUSTER._class,
+        customerId: data.customerID,
+        accountId: data.accountID,
+        provider: data.provider,
+        name: data.name,
+        region: data.region,
+        zone: data.zone,
+        agentConnected: data.agentConnected,
+        createdOn: parseTimePropertyValue(data.createdAt),
+        nodeCount: data.nodeCount,
+        clusterResourceGroup: data.clusterResourceGroup,
+        version: data.version,
+      },
+    },
+  });
+}

--- a/src/steps/clusters/converters.test.ts
+++ b/src/steps/clusters/converters.test.ts
@@ -1,0 +1,8 @@
+import { getMockCluster } from '../../../test/mocks';
+import { createClusterEntity } from './converter';
+
+describe('#createClusterEntity', () => {
+  test('should convert to entity', () => {
+    expect(createClusterEntity(getMockCluster())).toMatchSnapshot();
+  });
+});

--- a/src/steps/clusters/index.test.ts
+++ b/src/steps/clusters/index.test.ts
@@ -1,0 +1,37 @@
+import {
+  executeStepWithDependencies,
+  Recording,
+} from '@jupiterone/integration-sdk-testing';
+import { buildStepTestConfigForStep } from '../../../test/config';
+import { setupProjectRecording } from '../../../test/recording';
+import { Steps } from '../constants';
+
+let recording: Recording;
+
+afterEach(async () => {
+  await recording.stop();
+});
+
+test('#fetchClusters', async () => {
+  recording = setupProjectRecording({
+    directory: __dirname,
+    name: 'fetch-clusters',
+  });
+
+  const stepConfig = buildStepTestConfigForStep(Steps.CLUSTERS);
+  const stepResult = await executeStepWithDependencies(stepConfig);
+  expect(stepResult).toMatchStepMetadata(stepConfig);
+});
+
+test('#buildClusterAgentRelationship', async () => {
+  recording = setupProjectRecording({
+    directory: __dirname,
+    name: 'build-cluster-agent-relationship',
+  });
+
+  const stepConfig = buildStepTestConfigForStep(
+    Steps.BUILD_CLUSTER_AGENT_RELATIONSHIP,
+  );
+  const stepResult = await executeStepWithDependencies(stepConfig);
+  expect(stepResult).toMatchStepMetadata(stepConfig);
+});

--- a/src/steps/clusters/index.ts
+++ b/src/steps/clusters/index.ts
@@ -1,0 +1,89 @@
+import {
+  createDirectRelationship,
+  Entity,
+  getRawData,
+  IntegrationStep,
+  IntegrationStepExecutionContext,
+  RelationshipClass,
+} from '@jupiterone/integration-sdk-core';
+
+import { createAPIClient } from '../../client';
+import { IntegrationConfig } from '../../config';
+import { SysdigAgent } from '../../types';
+import { ACCOUNT_ENTITY_KEY } from '../account';
+import { Steps, Entities, Relationships } from '../constants';
+import { createClusterEntity, getClusterKey } from './converter';
+
+export async function fetchClusters({
+  instance,
+  jobState,
+}: IntegrationStepExecutionContext<IntegrationConfig>) {
+  const apiClient = createAPIClient(instance.config);
+  const accountEntity = (await jobState.getData(ACCOUNT_ENTITY_KEY)) as Entity;
+
+  await apiClient.iterateClusters(async (cluster) => {
+    const clusterEntity = await jobState.addEntity(
+      createClusterEntity(cluster),
+    );
+
+    await jobState.addRelationship(
+      createDirectRelationship({
+        _class: RelationshipClass.HAS,
+        from: accountEntity,
+        to: clusterEntity,
+      }),
+    );
+  });
+}
+
+export async function buildClusterAgentRelationship({
+  jobState,
+  logger,
+}: IntegrationStepExecutionContext<IntegrationConfig>) {
+  await jobState.iterateEntities(
+    { _type: Entities.AGENT._type },
+    async (agentEntity) => {
+      const agent = getRawData<SysdigAgent>(agentEntity);
+      if (!agent) {
+        logger.warn(
+          { _key: agentEntity._key },
+          'Could not get raw data for agent entity',
+        );
+        return;
+      }
+
+      const clusterEntity = await jobState.findEntity(
+        getClusterKey(agent.labels.provider, agent.clusterName),
+      );
+
+      if (clusterEntity) {
+        await jobState.addRelationship(
+          createDirectRelationship({
+            _class: RelationshipClass.SCANS,
+            from: agentEntity,
+            to: clusterEntity,
+          }),
+        );
+      }
+    },
+  );
+}
+
+export const clusterSteps: IntegrationStep<IntegrationConfig>[] = [
+  {
+    id: Steps.CLUSTERS,
+    name: 'Fetch Clusters',
+    entities: [Entities.CLUSTER],
+    relationships: [Relationships.ACCOUNT_HAS_CLUSTER],
+    dependsOn: [Steps.ACCOUNT],
+    executionHandler: fetchClusters,
+  },
+  {
+    id: Steps.BUILD_CLUSTER_AGENT_RELATIONSHIP,
+    name: 'Build Cluster and Agent Relationship',
+    entities: [],
+    relationships: [Relationships.AGENT_SCANS_CLUSTER],
+    dependsOn: [Steps.AGENTS, Steps.CLUSTERS],
+    executionHandler: buildClusterAgentRelationship,
+  },
+];

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -9,17 +9,28 @@ import {
 export const Steps = {
   ACCOUNT: 'fetch-account',
   USERS: 'fetch-users',
+  CLUSTERS: 'fetch-clusters',
+  AGENTS: 'fetch-agents',
   TEAMS: 'fetch-teams',
   IMAGE_SCANS: 'fetch-image-scans',
   SCANNER: 'fetch-scanner-details',
   FINDINGS: 'fetch-findings',
   BUILD_TEAM_AND_USER_RELATIONSHIP: 'build-team-and-user-relationship',
+  BUILD_CLUSTER_AGENT_RELATIONSHIP: 'build-cluster-and-agent-relationship',
   BUILD_SCANNER_AND_IMAGE_SCAN_RELATIONSHIP:
     'build-scanner-and-image-scan-relationship',
 };
 
 export const Entities: Record<
-  'ACCOUNT' | 'USER' | 'TEAM' | 'IMAGE_SCAN' | 'SCANNER' | 'FINDING' | 'CVE',
+  | 'ACCOUNT'
+  | 'USER'
+  | 'TEAM'
+  | 'IMAGE_SCAN'
+  | 'SCANNER'
+  | 'FINDING'
+  | 'CVE'
+  | 'CLUSTER'
+  | 'AGENT',
   StepEntityMetadata
 > = {
   ACCOUNT: {
@@ -57,6 +68,16 @@ export const Entities: Record<
     _type: 'cve',
     _class: ['Vulnerability'],
   },
+  CLUSTER: {
+    resourceName: 'Cluster',
+    _type: 'sysdig_cluster',
+    _class: ['Cluster'],
+  },
+  AGENT: {
+    resourceName: 'Agent',
+    _type: 'sysdig_agent',
+    _class: ['Scanner'],
+  },
 };
 
 export const MappedRelationships: Record<
@@ -76,6 +97,9 @@ export const Relationships: Record<
   | 'ACCOUNT_HAS_USER'
   | 'ACCOUNT_HAS_TEAM'
   | 'ACCOUNT_HAS_SCANNER'
+  | 'ACCOUNT_HAS_AGENT'
+  | 'ACCOUNT_HAS_CLUSTER'
+  | 'AGENT_SCANS_CLUSTER'
   | 'ACCOUNT_HAS_IMAGE_SCAN'
   | 'TEAM_HAS_USER'
   | 'SCANNER_PERFORMED_IMAGE_SCAN'
@@ -99,6 +123,24 @@ export const Relationships: Record<
     sourceType: Entities.ACCOUNT._type,
     _class: RelationshipClass.HAS,
     targetType: Entities.SCANNER._type,
+  },
+  ACCOUNT_HAS_AGENT: {
+    _type: 'sysdig_account_has_agent',
+    sourceType: Entities.ACCOUNT._type,
+    _class: RelationshipClass.HAS,
+    targetType: Entities.AGENT._type,
+  },
+  ACCOUNT_HAS_CLUSTER: {
+    _type: 'sysdig_account_has_cluster',
+    sourceType: Entities.ACCOUNT._type,
+    _class: RelationshipClass.HAS,
+    targetType: Entities.CLUSTER._type,
+  },
+  AGENT_SCANS_CLUSTER: {
+    _type: 'sysdig_agent_scans_cluster',
+    sourceType: Entities.AGENT._type,
+    _class: RelationshipClass.SCANS,
+    targetType: Entities.CLUSTER._type,
   },
   TEAM_HAS_USER: {
     _type: 'sysdig_team_has_user',

--- a/src/steps/index.ts
+++ b/src/steps/index.ts
@@ -4,6 +4,8 @@ import { teamsSteps } from './teams';
 import { scansSteps } from './scans';
 import { findingsSteps } from './findings';
 import { scannerSteps } from './scanner';
+import { clusterSteps } from './clusters';
+import { agentSteps } from './agents';
 
 const integrationSteps = [
   ...accountSteps,
@@ -12,6 +14,8 @@ const integrationSteps = [
   ...scansSteps,
   ...findingsSteps,
   ...scannerSteps,
+  ...clusterSteps,
+  ...agentSteps,
 ];
 
 export { integrationSteps };

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,3 +278,38 @@ export type Predicate = {
   type: string;
   extra?: any;
 };
+
+export type SysdigCluster = {
+  customerID: number;
+  accountID: string;
+  provider: string;
+  name: string;
+  region: string;
+  zone: string;
+  agentConnected: boolean;
+  createdAt: string;
+  nodeCount: number;
+  clusterResourceGroup: string;
+  version: string;
+  agentConnectString: string;
+};
+
+export type SysdigAgent = {
+  agentStatus: string;
+  agentIssues: {
+    reason: string;
+    status: string;
+    explanation: string;
+    fix: string;
+  }[];
+  clusterName: string;
+  labels: {
+    accountId: string;
+    hostname: string;
+    machineId: string;
+    provider: string;
+  };
+  moreOptions: {
+    agentConnectString: string;
+  };
+};

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -3,6 +3,8 @@ import {
   Policy,
   PolicyEvaluation,
   SysdigAccount,
+  SysdigAgent,
+  SysdigCluster,
   SysdigResult,
   SysdigTeam,
   SysdigUser,
@@ -259,6 +261,51 @@ export function getMockPolicy(partial?: Partial<Policy>): Policy {
     bundles: [],
     creationTimestamp: '2022-09-02T11:58:59.03062Z',
     updateTimestamp: '2022-09-02T11:58:59.03062Z',
+    ...partial,
+  };
+}
+
+export function getMockCluster(
+  partial?: Partial<SysdigCluster>,
+): SysdigCluster {
+  return {
+    customerID: 123456,
+    accountID: '30521231234',
+    provider: 'gcp',
+    name: 'sysdig-cluster',
+    region: 'us-central1',
+    zone: 'us-central1-c',
+    agentConnected: false,
+    createdAt: '2002-10-22T09:22:26Z',
+    nodeCount: 1,
+    clusterResourceGroup: '',
+    version: '1.23.8-gke.1900',
+    agentConnectString: 'connect string',
+    ...partial,
+  };
+}
+
+export function getMockAgent(partial?: Partial<SysdigAgent>): SysdigAgent {
+  return {
+    agentStatus: 'Never Connected',
+    agentIssues: [
+      {
+        reason: 'Never Connected',
+        status: 'Never Connected',
+        explanation: 'Agent was never connected.',
+        fix: 'review agent logs and/or network connectivity',
+      },
+    ],
+    clusterName: 'sysdig-cluster',
+    labels: {
+      accountId: '1234567890',
+      hostname: 'gke-sysdig-cluster-default-pool-12345678-6l1s',
+      machineId: '',
+      provider: 'gcp',
+    },
+    moreOptions: {
+      agentConnectString: 'agent connect string',
+    },
     ...partial,
   };
 }


### PR DESCRIPTION
- Added support for ingesting the following **new** entities:

| Resources | Entity `_type`   | Entity `_class` |
| --------- | ---------------- | --------------- |
| Agent     | `sysdig_agent`   | `Scanner`       |
| Cluster   | `sysdig_cluster` | `Cluster`       |

- Added support for ingesting the following **new** relationships:

| Source Entity `_type` | Relationship `_class` | Target Entity `_type` |
| --------------------- | --------------------- | --------------------- |
| `sysdig_agent`        | **SCANS**             | `sysdig_cluster`      |