### PR TITLE
Flatten fixablePackages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue related to `fixablePackages` property on the `sysdig_image_scan`
+  entity.
+
 ## 1.0.0 - 2022-11-01
 
 ### Added

--- a/src/steps/scans/__snapshots__/converters.test.ts.snap
+++ b/src/steps/scans/__snapshots__/converters.test.ts.snap
@@ -88,7 +88,6 @@ Object {
   "packageTypes": Array [
     "os",
   ],
-  "runningFixablePackages": null,
   "storedAt": 1663041226858,
   "summary": "Image Scan",
   "type": "dockerImage",

--- a/src/steps/scans/converter.ts
+++ b/src/steps/scans/converter.ts
@@ -74,7 +74,7 @@ export function createImageScanEntityV2(data: ImageScanV2): Entity {
         vulnsBySev,
         packageCount: data.packageCount,
         packageTypes: data.packageTypes,
-        fixablePackages: data.fixablePackages.map(
+        fixablePackages: data.fixablePackages?.map(
           (fixablePackage) =>
             `${fixablePackage.name}[${fixablePackage.version}]`,
         ),

--- a/src/steps/scans/converter.ts
+++ b/src/steps/scans/converter.ts
@@ -74,8 +74,10 @@ export function createImageScanEntityV2(data: ImageScanV2): Entity {
         vulnsBySev,
         packageCount: data.packageCount,
         packageTypes: data.packageTypes,
-        fixablePackages: data.fixablePackages,
-        runningFixablePackages: data.runningFixablePackages,
+        fixablePackages: data.fixablePackages.map(
+          (fixablePackage) =>
+            `${fixablePackage.name}[${fixablePackage.version}]`,
+        ),
         category: 'Image Scan',
         summary: 'Image Scan',
         internal: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,7 +144,15 @@ export type ImageScanV2 = {
   }[];
   packageCount: number;
   packageTypes: string[];
-  fixablePackages: any[];
+  fixablePackages: {
+    id: string;
+    type: string;
+    name: string;
+    version: string;
+    vulnsBySev: any[];
+    exploitCount: number;
+    suggestedFix: string;
+  }[];
   runningFixablePackages: any;
   policyEvaluations: PolicyEvaluation[];
   isEVEEnabled: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,7 +144,7 @@ export type ImageScanV2 = {
   }[];
   packageCount: number;
   packageTypes: string[];
-  fixablePackages: {
+  fixablePackages?: {
     id: string;
     type: string;
     name: string;


### PR DESCRIPTION
Fixed issue related to `fixablePackages` property on the `sysdig_image_scan` entity.

Our Sysdig account returned no data for `runningFixablePackages` and I wasn't able to find what the response object should look like, decided it might be safest to remove it from now so that we avoid running into runtime issue for some customer where that property is present and might be of a same/similar structure (array of objects). Let me know your thoughts about this @VDubber