### PR TITLE
Update converter.ts

### DIFF
--- a/src/steps/agents/converter.ts
+++ b/src/steps/agents/converter.ts
@@ -11,7 +11,7 @@ export function createAgentEntity(data: SysdigAgent): Entity {
     entityData: {
       source: data,
       assign: {
-        _key: `sysdig-agent:${data.labels.provider}-${data.labels.hostname}`,
+        _key: `sysdig-agent:${data.clusterName}-${data.machineId}-${data.labels.provider}-${data.labels.hostname}`,
         _type: Entities.AGENT._type,
         _class: Entities.AGENT._class,
         name: data.labels.hostname,


### PR DESCRIPTION
A multi tenant account can have multiple account with the objects containing the same provider and hostname. 

Extend the _key argument to include the cluster name and machine ID to ensure the _key is extra unique.